### PR TITLE
Add source code for fail.fmu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(FMU_UUID_DIR "${CMAKE_BINARY_DIR}/fmu-uuids"
 
 # The names of the FMUs built in this project
 set(fmus
+    "fail"
     "mock"
     "null"
 )

--- a/src/fail/modelDescription.xml
+++ b/src/fail/modelDescription.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<fmiModelDescription
+        fmiVersion="2.0"
+        modelName="com.open-simulation-platform.fail"
+        guid="@FMU_UUID@"
+        description="An FMU that does mostly nothing. It has one input, which is ignored until its value is set to true. This will cause a failure on the subsequent call to step."
+        author="Kristoffer Eide"
+        version="0.1">
+
+    <CoSimulation
+            modelIdentifier="fail"
+            canHandleVariableCommunicationStepSize="true"/>
+
+    <ModelVariables>
+        <ScalarVariable name="fail" valueReference="0" causality="input" variability="discrete">
+            <Boolean start="false"/>
+        </ScalarVariable>
+    </ModelVariables>
+
+    <ModelStructure/>
+
+</fmiModelDescription>

--- a/src/fail/sources/fmu.cpp
+++ b/src/fail/sources/fmu.cpp
@@ -1,0 +1,61 @@
+#include "fmu-uuid.h"
+
+#include <cppfmu_cs.hpp>
+
+#include <cstring>
+#include <stdexcept>
+
+class Slave : public cppfmu::SlaveInstance {
+public:
+  Slave() { Slave::Reset(); }
+
+  void Reset() override { input_ = false; }
+
+  void SetBoolean(const cppfmu::FMIValueReference vr[], std::size_t nvr,
+                  const cppfmu::FMIBoolean value[]) override {
+    for (std::size_t i = 0; i < nvr; ++i) {
+      if (vr[i] == 0) {
+        input_ = value[i];
+      } else {
+        throw std::logic_error("Invalid value reference");
+      }
+    }
+  }
+
+  void GetBoolean(const cppfmu::FMIValueReference vr[], std::size_t nvr,
+                  cppfmu::FMIBoolean value[]) const override {
+    for (std::size_t i = 0; i < nvr; ++i) {
+      if (vr[i] == 0) {
+        value[i] = input_;
+      } else {
+        throw std::logic_error("Invalid value reference");
+      }
+    }
+  }
+
+  bool DoStep(cppfmu::FMIReal /*currentCommunicationPoint*/,
+              cppfmu::FMIReal /*communicationStepSize*/,
+              cppfmu::FMIBoolean /*newStep*/,
+              cppfmu::FMIReal & /*endOfStep*/) override {
+    if (fmi2True == input_) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+private:
+  cppfmu::FMIBoolean input_;
+};
+
+cppfmu::UniquePtr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
+    cppfmu::FMIString /*instanceName*/, cppfmu::FMIString fmuGUID,
+    cppfmu::FMIString /*fmuResourceLocation*/, cppfmu::FMIString /*mimeType*/,
+    cppfmu::FMIReal /*timeout*/, cppfmu::FMIBoolean /*visible*/,
+    cppfmu::FMIBoolean /*interactive*/, cppfmu::Memory memory,
+    cppfmu::Logger /*logger*/) {
+  if (std::strcmp(fmuGUID, FMU_UUID) != 0) {
+    throw std::runtime_error("FMU GUID mismatch");
+  }
+  return cppfmu::AllocateUnique<Slave>(memory);
+}


### PR DESCRIPTION
`fail.fmu` is used in a cse-core test.